### PR TITLE
fix: incompatible version for expo and react-native packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "my-profile",
       "version": "1.0.0",
       "dependencies": {
-        "expo": "~53.0.11",
+        "expo": "53.0.12",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
-        "react-native": "0.79.3",
+        "react-native": "0.79.4",
         "react-native-safe-area-context": "5.4.0"
       },
       "devDependencies": {
@@ -1483,29 +1483,29 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.24.14",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.14.tgz",
-      "integrity": "sha512-o+QYyfIBhSRTgaywKTLJhm2Fg5PrSeUVCXS+uQySamgoMjLNhHa8QwE64mW/FmJr5hZLiqUEQxb60FK4JcyqXg==",
+      "version": "0.24.15",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.15.tgz",
+      "integrity": "sha512-RDZS30OSnbXkSPnBXdyPL29KbltjOmegE23bZZDiGV23WOReWcPgRc5U7Fd8eLPhtRjHBKlBpNJMTed5Ntr/uw==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "^0.0.5",
         "@expo/config": "~11.0.10",
-        "@expo/config-plugins": "~10.0.2",
+        "@expo/config-plugins": "~10.0.3",
         "@expo/devcert": "^1.1.2",
         "@expo/env": "~1.0.5",
         "@expo/image-utils": "^0.7.4",
         "@expo/json-file": "^9.1.4",
-        "@expo/metro-config": "~0.20.14",
+        "@expo/metro-config": "~0.20.15",
         "@expo/osascript": "^2.2.4",
         "@expo/package-manager": "^1.8.4",
         "@expo/plist": "^0.3.4",
-        "@expo/prebuild-config": "^9.0.6",
+        "@expo/prebuild-config": "^9.0.7",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "0.79.3",
+        "@react-native/dev-middleware": "0.79.4",
         "@urql/core": "^5.0.6",
         "@urql/exchange-retry": "^1.3.0",
         "accepts": "^1.3.8",
@@ -1598,18 +1598,18 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.0.2.tgz",
-      "integrity": "sha512-TzUn3pPdpwCS0yYaSlZOClgDmCX8N4I2lfgitX5oStqmvpPtB+vqtdyqsVM02fQ2tlJIAqwBW+NHaHqqy8Jv7g==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.0.3.tgz",
+      "integrity": "sha512-fjCckkde67pSDf48x7wRuPsgQVIqlDwN7NlOk9/DFgQ1hCH0L5pGqoSmikA1vtAyiA83MOTpkGl3F3wyATyUog==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^53.0.3",
+        "@expo/config-types": "^53.0.4",
         "@expo/json-file": "~9.1.4",
         "@expo/plist": "^0.3.4",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
-        "getenv": "^1.0.0",
+        "getenv": "^2.0.0",
         "glob": "^10.4.2",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
@@ -1617,15 +1617,6 @@
         "slugify": "^1.6.6",
         "xcode": "^3.0.1",
         "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/@expo/config-plugins/node_modules/getenv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
-      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/semver": {
@@ -1719,9 +1710,9 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.13.0.tgz",
-      "integrity": "sha512-3IwpH0p3uO8jrJSLOUNDzJVh7VEBod0emnCBq0hD72sy6ICmzauM6Xf4he+2Tip7fzImCJRd63GaehV+CCtpvA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.13.1.tgz",
+      "integrity": "sha512-MgZ5uIvvwAnjWeQoj4D3RnBXjD1GNOpCvhp2jtZWdQ8yEokhDEJGoHjsMT8/NCB5m2fqP5sv2V5nPzC7CN1YjQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -1730,6 +1721,7 @@
         "debug": "^4.3.4",
         "find-up": "^5.0.0",
         "getenv": "^2.0.0",
+        "glob": "^10.4.2",
         "ignore": "^5.3.1",
         "minimatch": "^9.0.0",
         "p-limit": "^3.1.0",
@@ -1810,16 +1802,16 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.20.14",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.20.14.tgz",
-      "integrity": "sha512-tYDDubuZycK+NX00XN7BMu73kBur/evOPcKfxc+UBeFfgN2EifOITtdwSUDdRsbtJ2OnXwMY1HfRUG3Lq3l4cw==",
+      "version": "0.20.15",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.20.15.tgz",
+      "integrity": "sha512-m8i58IQ7I8iOdVRfOhFmhPMHuhgeTVfQp1+mxW7URqPZaeVbuDVktPqOiNoHraKBoGPLKMUSsD+qdUuJVL3wMg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "@expo/config": "~11.0.9",
+        "@expo/config": "~11.0.10",
         "@expo/env": "~1.0.5",
         "@expo/json-file": "~9.1.4",
         "@expo/spawn-async": "^1.7.2",
@@ -1827,22 +1819,13 @@
         "debug": "^4.3.2",
         "dotenv": "~16.4.5",
         "dotenv-expand": "~11.0.6",
-        "getenv": "^1.0.0",
+        "getenv": "^2.0.0",
         "glob": "^10.4.2",
         "jsc-safe-url": "^0.2.4",
         "lightningcss": "~1.27.0",
         "minimatch": "^9.0.0",
         "postcss": "~8.4.32",
         "resolve-from": "^5.0.0"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/getenv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
-      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@expo/osascript": {
@@ -1884,17 +1867,17 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-9.0.6.tgz",
-      "integrity": "sha512-HDTdlMkTQZ95rd6EpvuLM+xkZV03yGLc38FqI37qKFLJtUN1WnYVaWsuXKoljd1OrVEVsHe6CfqKwaPZ52D56Q==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-9.0.7.tgz",
+      "integrity": "sha512-1w5MBp6NdF51gPGp0HsCZt0QC82hZWo37wI9HfxhdQF/sN/92Mh4t30vaY7gjHe71T5QNyab00oxZH/wP0MDgQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~11.0.9",
-        "@expo/config-plugins": "~10.0.2",
+        "@expo/config": "~11.0.10",
+        "@expo/config-plugins": "~10.0.3",
         "@expo/config-types": "^53.0.4",
         "@expo/image-utils": "^0.7.4",
         "@expo/json-file": "^9.1.4",
-        "@react-native/normalize-colors": "0.79.2",
+        "@react-native/normalize-colors": "0.79.4",
         "debug": "^4.3.1",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0",
@@ -2312,31 +2295,31 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.3.tgz",
-      "integrity": "sha512-Vy8DQXCJ21YSAiHxrNBz35VqVlZPpRYm50xRTWRf660JwHuJkFQG8cUkrLzm7AUriqUXxwpkQHcY+b0ibw9ejQ==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.4.tgz",
+      "integrity": "sha512-7PjHNRtYlc36B7P1PHme8ZV0ZJ/xsA/LvMoXe6EX++t7tSPJ8iYCMBryZhcdnztgce73b94Hfx6TTGbLF+xtUg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.3.tgz",
-      "integrity": "sha512-Zb8F4bSEKKZfms5n1MQ0o5mudDcpAINkKiFuFTU0PErYGjY3kZ+JeIP+gS6KCXsckxCfMEKQwqKicP/4DWgsZQ==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.4.tgz",
+      "integrity": "sha512-quhytIlDedR3ircRwifa22CaWVUVnkxccrrgztroCZaemSJM+HLurKJrjKWm0J5jV9ed+d+9Qyb1YB0syTHDjg==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.79.3"
+        "@react-native/codegen": "0.79.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.3.tgz",
-      "integrity": "sha512-VHGNP02bDD2Ul1my0pLVwe/0dsEBHxR343ySpgnkCNEEm9C1ANQIL2wvnJrHZPcqfAkWfFQ8Ln3t+6fdm4A/Dg==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.4.tgz",
+      "integrity": "sha512-El9JvYKiNfnkQ3qR7zJvvRdP3DX2i4BGYlIricWQishI3gWAfm88FQYFC2CcGoMQWJQEPN4jnDMpoISAJDEN4g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -2380,7 +2363,7 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.79.3",
+        "@react-native/babel-plugin-codegen": "0.79.4",
         "babel-plugin-syntax-hermes-parser": "0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
@@ -2393,9 +2376,9 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.3.tgz",
-      "integrity": "sha512-CZejXqKch/a5/s/MO5T8mkAgvzCXgsTkQtpCF15kWR9HN8T+16k0CsN7TXAxXycltoxiE3XRglOrZNEa/TiZUQ==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.4.tgz",
+      "integrity": "sha512-K0moZDTJtqZqSs+u9tnDPSxNsdxi5irq8Nu4mzzOYlJTVNGy5H9BiIDg/NeKGfjAdo43yTDoaPSbUCvVV8cgIw==",
       "license": "MIT",
       "dependencies": {
         "glob": "^7.1.1",
@@ -2455,12 +2438,12 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.3.tgz",
-      "integrity": "sha512-N/+p4HQqN4yK6IRzn7OgMvUIcrmEWkecglk1q5nj+AzNpfIOzB+mqR20SYmnPfeXF+mZzYCzRANb3KiM+WsSDA==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.4.tgz",
+      "integrity": "sha512-lx1RXEJwU9Tcs2B2uiDZBa6yghU6m6STvwYqHbJlFZyNN1k3JRa9j0/CDu+0fCFacIn7rEfZpb4UWi5YhsHpQg==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.3",
+        "@react-native/dev-middleware": "0.79.4",
         "chalk": "^4.0.0",
         "debug": "^2.2.0",
         "invariant": "^2.2.4",
@@ -2509,22 +2492,22 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.3.tgz",
-      "integrity": "sha512-ImNDuEeKH6lEsLXms3ZsgIrNF94jymfuhPcVY5L0trzaYNo9ZFE9Ni2/18E1IbfXxdeIHrCSBJlWD6CTm7wu5A==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.4.tgz",
+      "integrity": "sha512-Gg4LhxHIK86Bi2RiT1rbFAB6fuwANRsaZJ1sFZ1OZEMQEx6stEnzaIrmfgzcv4z0bTQdQ8lzCrpsz0qtdaD4eA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.3.tgz",
-      "integrity": "sha512-x88+RGOyG71+idQefnQg7wLhzjn/Scs+re1O5vqCkTVzRAc/f7SdHMlbmECUxJPd08FqMcOJr7/X3nsJBrNuuw==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.4.tgz",
+      "integrity": "sha512-OWRDNkgrFEo+OSC5QKfiiBmGXKoU8gmIABK8rj2PkgwisFQ/22p7MzE5b6oB2lxWaeJT7jBX5KVniNqO46VhHA==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.3",
+        "@react-native/debugger-frontend": "0.79.4",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
@@ -2564,27 +2547,27 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.3.tgz",
-      "integrity": "sha512-imfpZLhNBc9UFSzb/MOy2tNcIBHqVmexh/qdzw83F75BmUtLb/Gs1L2V5gw+WI1r7RqDILbWk7gXB8zUllwd+g==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.4.tgz",
+      "integrity": "sha512-Gv5ryy23k7Sib2xVgqw65GTryg9YTij6URcMul5cI7LRcW0Aa1/FPb26l388P4oeNGNdDoAkkS+CuCWNunRuWg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.3.tgz",
-      "integrity": "sha512-PEBtg6Kox6KahjCAch0UrqCAmHiNLEbp2SblUEoFAQnov4DSxBN9safh+QSVaCiMAwLjvNfXrJyygZz60Dqz3Q==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.4.tgz",
+      "integrity": "sha512-VyKPo/l9zP4+oXpQHrJq4vNOtxF7F5IMdQmceNzTnRpybRvGGgO/9jYu9mdmdKRO2KpQEc5dB4W2rYhVKdGNKg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.2.tgz",
-      "integrity": "sha512-+b+GNrupWrWw1okHnEENz63j7NSMqhKeFMOyzYLBwKcprG8fqJQhDIGXfizKdxeIa5NnGSAevKL1Ev1zJ56X8w==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.4.tgz",
+      "integrity": "sha512-247/8pHghbYY2wKjJpUsY6ZNbWcdUa5j5517LZMn6pXrbSSgWuj3JA4OYibNnocCHBaVrt+3R8XC3VEJqLlHFg==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
@@ -3057,9 +3040,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.2.0.tgz",
-      "integrity": "sha512-oNUeUZPMNRPmx/2jaKJLSQFP/MFI1M91vP+Gp+j8/FPl9p/ps603DNwCaRdcT/Vj3FfREdlIwRio1qDCjY0oAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.2.1.tgz",
+      "integrity": "sha512-Ol3w0uLJNQ5tDfCf4L+IDTDMgJkVMQHhvYqMxs18Ib0DcaBQIfE8mneSSk7FcuI6FS0phw/rZhoEquQh1/Q3wA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -3076,7 +3059,7 @@
         "@babel/plugin-transform-runtime": "^7.24.7",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.79.3",
+        "@react-native/babel-preset": "0.79.4",
         "babel-plugin-react-native-web": "~0.19.13",
         "babel-plugin-syntax-hermes-parser": "^0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
@@ -3950,25 +3933,25 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "53.0.11",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.11.tgz",
-      "integrity": "sha512-+QtvU+6VPd7/o4vmtwuRE/Li2rAiJtD25I6BOnoQSxphaWWaD0PdRQnIV3VQ0HESuJYRuKJ3DkAHNJ3jI6xwzA==",
+      "version": "53.0.12",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.12.tgz",
+      "integrity": "sha512-dtmED749hkxDWCcvtD++tb8bAm3Twv8qnUOXzVyXA5owNG0mwDIz0HveJTpWK1UzkY4HcTVRezDf0tflZJ+JXQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.24.14",
+        "@expo/cli": "0.24.15",
         "@expo/config": "~11.0.10",
-        "@expo/config-plugins": "~10.0.2",
-        "@expo/fingerprint": "0.13.0",
-        "@expo/metro-config": "0.20.14",
+        "@expo/config-plugins": "~10.0.3",
+        "@expo/fingerprint": "0.13.1",
+        "@expo/metro-config": "0.20.15",
         "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~13.2.0",
+        "babel-preset-expo": "~13.2.1",
         "expo-asset": "~11.1.5",
         "expo-constants": "~17.1.6",
         "expo-file-system": "~18.1.10",
         "expo-font": "~13.3.1",
         "expo-keep-awake": "~14.1.4",
-        "expo-modules-autolinking": "2.1.11",
+        "expo-modules-autolinking": "2.1.12",
         "expo-modules-core": "2.4.0",
         "react-native-edge-to-edge": "1.6.0",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -4060,9 +4043,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.11.tgz",
-      "integrity": "sha512-KrWQo+cE4gWYNePBBhmHGVzf63gYV19ZLXe9EIH3GHTkViVzIX+Lp618H/7GxfawpN5kbhvilATH1QEKKnUUww==",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.12.tgz",
+      "integrity": "sha512-rW5YSW66pUx1nLqn7TO0eWRnP4LDvySW1Tom0wjexk3Tx/upg9LYE5tva7p5AX/cdFfiZcEqPcOxP4RyT++Xlg==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -6481,19 +6464,19 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.3.tgz",
-      "integrity": "sha512-EzH1+9gzdyEo9zdP6u7Sh3Jtf5EOMwzy+TK65JysdlgAzfEVfq4mNeXcAZ6SmD+CW6M7ARJbvXLyTD0l2S5rpg==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.4.tgz",
+      "integrity": "sha512-CfxYMuszvnO/33Q5rB//7cU1u9P8rSOvzhE2053Phdb8+6bof9NLayCllU2nmPrm8n9o6RU1Fz5H0yquLQ0DAw==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.3",
-        "@react-native/codegen": "0.79.3",
-        "@react-native/community-cli-plugin": "0.79.3",
-        "@react-native/gradle-plugin": "0.79.3",
-        "@react-native/js-polyfills": "0.79.3",
-        "@react-native/normalize-colors": "0.79.3",
-        "@react-native/virtualized-lists": "0.79.3",
+        "@react-native/assets-registry": "0.79.4",
+        "@react-native/codegen": "0.79.4",
+        "@react-native/community-cli-plugin": "0.79.4",
+        "@react-native/gradle-plugin": "0.79.4",
+        "@react-native/js-polyfills": "0.79.4",
+        "@react-native/normalize-colors": "0.79.4",
+        "@react-native/virtualized-lists": "0.79.4",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -6569,16 +6552,10 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.3.tgz",
-      "integrity": "sha512-T75NIQPRFCj6DFMxtcVMJTZR+3vHXaUMSd15t+CkJpc5LnyX91GVaPxpRSAdjFh7m3Yppl5MpdjV/fntImheYQ==",
-      "license": "MIT"
-    },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.3.tgz",
-      "integrity": "sha512-/0rRozkn+iIHya2vnnvprDgT7QkfI54FLrACAN3BLP7MRlfOIGOrZsXpRLndnLBVnjNzkcre84i1RecjoXnwIA==",
+      "version": "0.79.4",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.4.tgz",
+      "integrity": "sha512-0Mdcox6e5PTonuM1WIo3ks7MBAa3IDzj0pKnE5xAwSgQ0DJW2P5dYf+KjWmpkE+Yb0w41ZbtXPhKq+U2JJ6C/Q==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4",
@@ -7563,9 +7540,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.42.0.tgz",
-      "integrity": "sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.0.tgz",
+      "integrity": "sha512-CqNNxKSGKSZCunSvwKLTs8u8sGGlp27sxNZ4quGh0QeNuyHM0JSEM/clM9Mf4zUp6J+tO2gUXhgXT2YMMkwfKQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "expo": "~53.0.11",
+    "expo": "53.0.12",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.3",
+    "react-native": "0.79.4",
     "react-native-safe-area-context": "5.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
this fix will help avoid fail when deploying the app
```
-    "expo": "~53.0.11",
+    "expo": "53.0.12",

-    "react-native": "0.79.3",
+    "react-native": "0.79.4",
```